### PR TITLE
Also serve webjar with exact lib version in the request path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,17 @@ Require the middleware and add it to your handler.
 (def app (wrap-webjars handler)
 ```
 
-WebJar assets will then be served from the following path:
+WebJar assets will then be served from the following paths:
 
     /assets/<webjar>/<asset path>
+    /assets/<webjar>/<webjar-version>/<asset path>
 
 For example, if you include the `[org.webjars/bootstrap "3.3.5"]`
-dependency, then the minified bootstrap CSS will be available at:
+dependency, then the minified bootstrap CSS will be available at
+paths:
 
     /assets/bootstrap/css/bootstrap.min.css
+    /assets/bootstrap/3.3.5/css/bootstrap.min.css
 
 By default assets are placed on the `/assets` path. You can change
 the path by specifying a second argument.

--- a/src/ring/middleware/webjars.clj
+++ b/src/ring/middleware/webjars.clj
@@ -8,13 +8,14 @@
 (def ^:private webjars-pattern
   #"META-INF/resources/webjars/([^/]+)/([^/]+)/(.*)")
 
-(defn- asset-path [prefix resource]
-  (let [[_ name version path] (re-matches webjars-pattern resource)]
-    (str prefix "/" name "/" path)))
+(defn- asset-paths [prefix resource]
+  (let [[_ name version filename] (re-matches webjars-pattern resource)]
+    {(str prefix "/" name "/" version "/" filename) resource
+     (str prefix "/" name "/" filename)             resource}))
 
 (defn- asset-map [^WebJarAssetLocator locator prefix]
   (->> (.listAssets locator "")
-       (map (juxt (partial asset-path prefix) identity))
+       (map (partial asset-paths prefix))
        (into {})))
 
 (defn- request-path [request]

--- a/test/ring/middleware/webjars_test.clj
+++ b/test/ring/middleware/webjars_test.clj
@@ -27,6 +27,9 @@
       (is (nil? (handler (get-req "/assets/bootstrap"))))
       (let [resp (handler (get-req "/assets/bootstrap/less/close.less"))]
         (is (= (slurp (:body resp))
+               (slurp-webjars "bootstrap/3.3.5/less/close.less"))))
+      (let [resp (handler (get-req "/assets/bootstrap/3.3.5/less/close.less"))]
+        (is (= (slurp (:body resp))
                (slurp-webjars "bootstrap/3.3.5/less/close.less"))))))
 
   (testing "async handlers"
@@ -36,4 +39,7 @@
       (is (nil? (async-response handler (get-req "/assets/bootstrap"))))
       (let [resp (async-response handler (get-req "/assets/bootstrap/less/close.less"))]
         (is (= (slurp (:body resp))
-               (slurp-webjars "bootstrap/3.3.5/less/close.less")))))))
+               (slurp-webjars "bootstrap/3.3.5/less/close.less")))
+        (let [resp (async-response handler (get-req "/assets/bootstrap/3.3.5/less/close.less"))]
+          (is (= (slurp (:body resp))
+                 (slurp-webjars "bootstrap/3.3.5/less/close.less"))))))))


### PR DESCRIPTION
Adds possibility to request the webjar contents with the lib version in the request path.

Previously contents could be requested only with:
- `"/assets/bootstrap/less/close.less"`

With this PR contents can be requested with:
- `"/assets/bootstrap/less/close.less"`
- `"/assets/bootstrap/3.3.5/less/close.less"`

Rationale: proxy/cache busting. Ensure that the browser doesn't find a match in the cache when a webjar version is bumped since the request URI changes if it includes the lib version.